### PR TITLE
Added option to roll passively to roll dialogues.

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1916,6 +1916,7 @@
   "A5E.RollModeNormal": "Normal",
   "A5E.RollModeAdvantage": "Advantage",
   "A5E.RollModeDisadvantage": "Disadvantage",
+  "A5E.RollModePassive": "Passive",
   "A5E.RollAbilityCheck": "Roll Ability Check",
   "A5E.RollInitiative": "Roll Initiative",
   "A5E.RollSavingThrow": "Roll Saving Throw",

--- a/src/apps/chat/body/RollConfigurationOptions.svelte
+++ b/src/apps/chat/body/RollConfigurationOptions.svelte
@@ -10,6 +10,8 @@
         [1, "Advantage"],
         [0, "Normal"],
         [-1, "Disadvantage"],
+        [2, "Passive"],
+
     ];
 
     const expertiseDice = [

--- a/src/apps/chat/body/RollSummary.svelte
+++ b/src/apps/chat/body/RollSummary.svelte
@@ -36,11 +36,10 @@
     function getRollModeLabel({ rollMode }) {
         if (!rollMode) return null;
 
-        return localize(
-            rollMode === 1
-                ? "A5E.RollModeAdvantage"
-                : "A5E.RollModeDisadvantage",
-        );
+      return localize(
+          rollMode === 1 ? "A5E.RollModeAdvantage" :
+          (rollMode === 2 ? "A5E.RollModePassive" : "A5E.RollModeDisadvantage")
+      );
     }
 
     function getExpertiseLabel({ expertiseDice }) {

--- a/src/config.js
+++ b/src/config.js
@@ -96,7 +96,8 @@ A5E.PREPARED_STATES = {
 A5E.ROLL_MODE = {
   NORMAL: 0,
   ADVANTAGE: 1,
-  DISADVANTAGE: -1
+  DISADVANTAGE: -1,
+  PASSIVE: 2
 };
 
 /**
@@ -694,7 +695,8 @@ A5E.resourceRecoveryOptions = {
 A5E.rollModes = {
   normal: 'A5E.RollModeNormal',
   advantage: 'A5E.RollModeAdvantage',
-  disadvantage: 'A5E.RollModeDisadvantage'
+  disadvantage: 'A5E.RollModeDisadvantage',
+  passive: 'A5E.RollModePassive'
 };
 
 // TODO: Add localizations for these roll types.

--- a/src/dice/constructD20Term.js
+++ b/src/dice/constructD20Term.js
@@ -5,6 +5,10 @@ export default function constructD20Term({ actor, minRoll, rollMode }) {
     d20Term = '2d20';
   }
 
+  if ([CONFIG.A5E.ROLL_MODE.PASSIVE].includes(rollMode)) {
+    d20Term = '10';
+  }
+
   if (actor?.flags?.a5e?.halflingLuck) d20Term += 'r1';
 
   if (minRoll > 1) d20Term += `min${minRoll}`;

--- a/src/managers/RollPreparationManager.js
+++ b/src/managers/RollPreparationManager.js
@@ -123,8 +123,10 @@ export default class RollPreparationManager {
     const critThreshold = _roll.critThreshold ?? 20;
     const roll = await new Roll(rollFormula).evaluate({ async: true });
     const label = localize(CONFIG.A5E.attackTypes[_roll?.attackType ?? 'meleeWeaponAttack']);
-
-    const isCrit = roll.dice[0].total >= critThreshold;
+    const isCrit = false;
+    if (roll.dice[0] !== undefined) {
+      const isCrit = roll.dice[0].total >= critThreshold;
+    }
 
     return {
       attackType: _roll.attackType,


### PR DESCRIPTION
Added a new RollMode for Passive Rolls. Allows a user to roll using a base 10 instead of any number of d20. 
Adjusts attack crit logic to be able to handle the non-dice input.

Caveats: *Does not handle Expertise Dice as RAW. 

Initially made in order to allow rolling initiative for NPC's as passives.